### PR TITLE
[Feature] Add theme toggle to app 

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -11,14 +11,15 @@
     "format:check": "prettier --check ./src"
   },
   "dependencies": {
-    "@next/font": "^14.2.15",
     "@clerk/nextjs": "^6.1.0",
+    "@next/font": "^14.2.15",
     "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-slot": "^1.1.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.454.0",
     "next": "15.0.2",
+    "next-themes": "^0.3.0",
     "react": "19.0.0-rc-02c0e824-20241028",
     "react-dom": "19.0.0-rc-02c0e824-20241028",
     "tailwind-merge": "^2.5.4",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       next:
         specifier: 15.0.2
         version: 15.0.2(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028)
+      next-themes:
+        specifier: ^0.3.0
+        version: 0.3.0(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028)
       react:
         specifier: 19.0.0-rc-02c0e824-20241028
         version: 19.0.0-rc-02c0e824-20241028
@@ -1576,6 +1579,12 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  next-themes@0.3.0:
+    resolution: {integrity: sha512-/QHIrsYpd6Kfk7xakK4svpDI5mmXP0gfvCoJdGpZQ2TOrQZmsW0QxjaiLn8wbIKjtm4BTSqLoix4lxYYOnLJ/w==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18
+      react-dom: ^16.8 || ^17 || ^18
 
   next@15.0.2:
     resolution: {integrity: sha512-rxIWHcAu4gGSDmwsELXacqAPUk+j8dV/A9cDF5fsiCMpkBDYkO2AEaL1dfD+nNmDiU6QMCFN8Q30VEKapT9UHQ==}
@@ -3239,7 +3248,7 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 9.14.0(jiti@1.21.6)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.12.2(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.14.0(jiti@1.21.6))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -3252,7 +3261,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.12.2(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.14.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -3274,7 +3283,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.14.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.12.2(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.14.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -3793,6 +3802,11 @@ snapshots:
   nanoid@3.3.7: {}
 
   natural-compare@1.4.0: {}
+
+  next-themes@0.3.0(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028):
+    dependencies:
+      react: 19.0.0-rc-02c0e824-20241028
+      react-dom: 19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028)
 
   next@15.0.2(react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028))(react@19.0.0-rc-02c0e824-20241028):
     dependencies:

--- a/web/src/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/web/src/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -2,7 +2,7 @@ import { SignIn } from "@clerk/nextjs";
 
 export default function SignInPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center py-4">
+    <div className="flex min-h-screen items-center justify-center py-4">
       <SignIn />
     </div>
   );

--- a/web/src/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/web/src/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -2,7 +2,7 @@ import { SignUp } from "@clerk/nextjs";
 
 export default function SIgnUpPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center py-4">
+    <div className="flex min-h-screen items-center justify-center py-4">
       <SignUp />
     </div>
   );

--- a/web/src/app/feed/page.tsx
+++ b/web/src/app/feed/page.tsx
@@ -8,17 +8,20 @@ export default async function FeedPage() {
   if (_?.userId) {
     user = await currentUser();
   }
-  
+
   return (
     <div className="">
       Feed Page
-
       <pre>
-        {JSON.stringify({
-          _,
-          user,
-        }, null, 2)}
+        {JSON.stringify(
+          {
+            _,
+            user,
+          },
+          null,
+          2
+        )}
       </pre>
     </div>
   );
-};
+}

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -2,15 +2,16 @@ import type { Metadata } from "next";
 import localFont from "next/font/local";
 import {
   ClerkProvider,
-  SignInButton,
-  SignedIn,
-  SignedOut,
-  ClerkLoaded,
-  ClerkLoading,
-  UserButton
+  // SignInButton,
+  // SignedIn,
+  // SignedOut,
+  // ClerkLoaded,
+  // ClerkLoading,
+  // UserButton,
 } from "@clerk/nextjs";
 
 import "./globals.css";
+import ThemeProvider from "@/components/themes/themes-provider";
 
 // import {Roboto_Mono} from '@next/font/google'
 // const roboto_mono = Roboto_Mono({
@@ -100,6 +101,14 @@ export default function RootLayout({
         <body
           className={`${geistSans.variable} ${geistMono.variable} antialiased`}
         >
+          <ThemeProvider
+            attribute="class"
+            defaultTheme="system"
+            enableSystem
+            disableTransitionOnChange
+          >
+            {children}
+          </ThemeProvider>
           {/* <SignedOut>
             <SignInButton />
           </SignedOut>
@@ -114,7 +123,6 @@ export default function RootLayout({
           <ClerkLoaded>
             <div>Content Loaded</div>
           </ClerkLoaded> */}
-          {children}
         </body>
       </html>
     </ClerkProvider>

--- a/web/src/app/profile/page.tsx
+++ b/web/src/app/profile/page.tsx
@@ -6,5 +6,5 @@ export default function ProfilePage() {
     <MainTag>
       <UserButton />
     </MainTag>
-  )
+  );
 }

--- a/web/src/core/components/atoms/text-logo.tsx
+++ b/web/src/core/components/atoms/text-logo.tsx
@@ -18,7 +18,7 @@ export function TextLogo({
   return (
     <span
       className={cn(
-        "flex w-fit items-center justify-center font-bold text-app-text-dark-500",
+        "flex w-fit items-center justify-center font-bold ",
         className
       )}
       {...restProps}

--- a/web/src/core/components/home-page/footer.tsx
+++ b/web/src/core/components/home-page/footer.tsx
@@ -1,5 +1,5 @@
 import { Facebook, Github, Instagram, X } from "lucide-react";
-import { Textlogo } from "../atoms";
+import { TextLogo } from "../atoms";
 
 export default function Footer() {
   return (

--- a/web/src/core/components/home-page/footer.tsx
+++ b/web/src/core/components/home-page/footer.tsx
@@ -18,7 +18,7 @@ export default function Footer() {
           <Github />
         </div>
       </div>
-      <div className="flex w-full flex-col items-center justify-between gap-2 border-t border-solid pt-4 text-app-text-dark-200 md:flex-row">
+      <div className="flex w-full flex-col items-center justify-between gap-2 border-t border-solid pt-4 font-light md:flex-row">
         <span className="">&copy;Copyright all right reserved</span>
         <div className="flex flex-col items-center justify-between gap-4 md:flex-row">
           <h4>Privacy Policy</h4>

--- a/web/src/core/components/home-page/header.tsx
+++ b/web/src/core/components/home-page/header.tsx
@@ -2,6 +2,7 @@ import { TextLogo } from "@/components/atoms/";
 import { Button } from "../ui/button";
 import Link from "next/link";
 import { SignedIn, SignedOut } from "@clerk/nextjs";
+import ModeToogle from "../ui/mode-toogle";
 
 export default function Header() {
   return (
@@ -33,6 +34,8 @@ export default function Header() {
             <Link href="/feed">Continue</Link>
           </Button>
         </SignedIn>
+
+        <ModeToogle />
       </div>
     </header>
   );

--- a/web/src/core/components/home-page/hero-section.tsx
+++ b/web/src/core/components/home-page/hero-section.tsx
@@ -25,10 +25,11 @@ export default async function HeroSection() {
         </p>
 
         <Button className="flex w-fit">
-          <Link href={isAuthenTicated ? "/feed" : "/sign-in"} className="flex w-fit items-center gap-4">
-            {
-              isAuthenTicated ? "Welcome back" : "Be InTouch Now"
-            }
+          <Link
+            href={isAuthenTicated ? "/feed" : "/sign-in"}
+            className="flex w-fit items-center gap-4"
+          >
+            {isAuthenTicated ? "Welcome back" : "Be InTouch Now"}
             <ArrowRight />
           </Link>
         </Button>

--- a/web/src/core/components/themes/themes-provider.tsx
+++ b/web/src/core/components/themes/themes-provider.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { ThemeProvider as NexThemeProvider } from "next-themes";
+import { type ThemeProviderProps } from "next-themes/dist/types";
+
+export default function ThemeProvider({
+  children,
+  ...props
+}: ThemeProviderProps) {
+  return <NexThemeProvider {...props}>{children}</NexThemeProvider>;
+}

--- a/web/src/core/components/ui/mode-toogle.tsx
+++ b/web/src/core/components/ui/mode-toogle.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { MoonIcon, SunIcon } from "lucide-react";
+import { Button } from "./button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "./dropdown-menu";
+import { useTheme } from "next-themes";
+
+export default function ModeToogle() {
+  const { setTheme } = useTheme();
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" className="border-none outline-none">
+          <SunIcon className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <MoonIcon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent>
+        <DropdownMenuItem onClick={() => setTheme("light")}>
+          Light
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
+          Dark
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          System
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -3,7 +3,7 @@ import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 /**
  * See clerk docs
  * @see https://clerk.com/docs/references/nextjs/custom-signup-signin-pages#make-the-sign-up-and-sign-in-routes-public
-*/
+ */
 const publicRoutes = ["/", "/sign-in(.*)", "/sign-up(.*)"];
 
 const isPublicRoute = createRouteMatcher(publicRoutes);
@@ -14,7 +14,7 @@ export default clerkMiddleware(
       await auth.protect();
     }
   },
-  { debug: process.env.NODE_ENV === "development" },
+  { debug: process.env.NODE_ENV === "development" }
 );
 
 export const config = {


### PR DESCRIPTION
- [x] **Toggle Mode UI**: Created a toggle mode UI, utilizing the Shatin dropdown menu for theme-switching functionality.
- [x] **Theme Provider Setup**: Installed and configured `next-themes`, establishing a `ThemeProvider` within the `core/theme` directory.
- [x] **Global Integration**: Wrapped the entire app in the theme provider, passing the `children` prop using the spread prop and added  `attribute` for theme control.

  

Resolves #19 